### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ spec:
         licensing:
           licenseKey: ${GLOO_MESH_LICENSE_KEY}
         common:
-          cluster: "${MY_CLUSTER_CONTEXT}"
+          cluster: "${MY_CLUSTER_NAME}"
         glooMgmtServer:
           enabled: true
           serviceType: ClusterIP

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 GitOps is becoming increasingly popular approach to manage Kubernetes components. It works by using Git as a single source of truth for declarative infrastructure and applications, allowing your application definitions, configurations, and environments to be declarative and version controlled. This helps to make these workflows automated, auditable, and easy to understand.
 
 ## Purpose of this Tutorial
-The main goal of this tutorial is to showcase how Gloo Platform components can seamlessly integrate into a GitOps workflow, with Argo CD being our tool of choice. We'll guide you through the installation of Argo CD, Gloo Platform, Istio, and finally, we'll explore the Gloo Platform Dashboard.
+The main goal of this tutorial is to showcase how Gloo Mesh components can seamlessly integrate into a GitOps workflow, with Argo CD being our tool of choice. We'll guide you through the installation of Argo CD, Gloo Platform, Istio, and finally, we'll explore the Gloo Mesh Dashboard.
 
 ## High Level Architecture
 ![High Level Architecture](.images/single-cluster-arch1.png)

--- a/README.md
+++ b/README.md
@@ -255,10 +255,10 @@ gloo-mesh | gloo-telemetry-collector-agent | 2/2   | Healthy
 🟢 Mgmt server connectivity to workload agents
 
 Cluster                         | Registered | Connected Pod
-demo-gloo-platform-cluster-arka | true       | gloo-mesh/gloo-mesh-mgmt-server-69b9d9567b-nld5f
+demo-gloo-platform-cluster-arka | true       | gloo-mesh/gloo-mesh-mgmt-server-7f6968d9b9-67l7j
 
 Connected Pod                                    | Clusters
-gloo-mesh/gloo-mesh-mgmt-server-69b9d9567b-nld5f | 1
+gloo-mesh/gloo-mesh-mgmt-server-7f6968d9b9-67l7j | 1
 ```
 
 At this point, we should be able to access our Gloo Platform UI using port-forward at http://localhost:8090
@@ -417,7 +417,7 @@ spec:
             targetPort: 443
           annotations:
             # AWS NLB Annotation
-            service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+            service.beta.kubernetes.io/aws-load-balancer-type: "nlb-ip"
           loadBalancerIP: ""
           loadBalancerSourceRanges: []
           externalTrafficPolicy: ""

--- a/README.md
+++ b/README.md
@@ -442,22 +442,22 @@ EOF
 ```
 
 You can check to see that istiod and the istio ingressgateways have been deployed
-```
-kubectl get pods -n istio-system --context "${MY_CLUSTER_CONTEXT}" && kubectl get pods -n istio-gateways --context "${MY_CLUSTER_CONTEXT}"
+```bash
+kubectl get pods -n istio-system --context "${MY_CLUSTER_CONTEXT}" && \
+kubectl get pods -n istio-gateways --context "${MY_CLUSTER_CONTEXT}"
 ```
 
 Output should look similar to below:
-```
-% kubectl get pods -n istio-system --context "${MY_CLUSTER_CONTEXT}" && kubectl get pods -n istio-gateways --context "${MY_CLUSTER_CONTEXT}"
-NAME                          READY   STATUS    RESTARTS   AGE
-istiod-1-19-b6ff5fbf7-92bx9   1/1     Running   0          60s
-NAME                                         READY   STATUS    RESTARTS   AGE
-istio-ingressgateway-1-19-844fc985cd-hfbm5   1/1     Running   0          45s
+```bash
+NAME                             READY   STATUS    RESTARTS   AGE
+istiod-1-19-6-86499c5945-bbsfl   1/1     Running   0          38m
+NAME                                           READY   STATUS    RESTARTS   AGE
+istio-ingressgateway-1-19-6-6575484979-5fbn7   1/1     Running   0          36m
 ```
 
 ### Visualize in Gloo Mesh Dashboard
 Access Gloo Mesh Dashboard at `http://localhost:8090`:
-```
+```bash
 kubectl port-forward -n gloo-mesh svc/gloo-mesh-ui 8090 --context "${MY_CLUSTER_CONTEXT}"
 ```
 
@@ -471,26 +471,26 @@ To avoid storing the license key in Git, we can enhance security by utilizing a 
 
 ## Provide Gloo Mesh Enterprise License Key variable
 In case you havent configured it already, Gloo Mesh Enterprise requires a Trial License Key:
-```
+```bash
 GLOO_MESH_LICENSE_KEY=<input_license_key_here>
 ```
 
 The license is stored as a base64 encoded secret, set your the following variable based on your OS:
 
 For Linux:
-```
+```bash
 # Linux
     BASE64_LICENSE_KEY=$(echo -n "${GLOO_MESH_LICENSE_KEY}" | base64 -w 0)
 ```
 
 For Mac:
-```
+```bash
 # Mac OSX
     BASE64_LICENSE_KEY=$(echo -n "${GLOO_MESH_LICENSE_KEY}" | base64 | tr -d '[:space:]')
 ```
 
 Create the license secret:
-```
+```bash
 # Create namespace for Gloo Mesh
 kubectl create ns gloo-mesh --context "${MY_CLUSTER_CONTEXT}"
 
@@ -511,7 +511,7 @@ EOF
 ```
 
 Now we can deploy an Argo app-of-app which will configure the entire setup that we walked through in the previous section
-```
+```bash
 kubectl apply --context "${MY_CLUSTER_CONTEXT}" -f - <<EOF
 apiVersion: argoproj.io/v1alpha1
 kind: Application
@@ -544,7 +544,7 @@ EOF
 ```
 
 You can check to see that Gloo Mesh, Istiod and the Istio ingressgateways have been deployed
-```
+```bash
 kubectl get pods -n gloo-mesh --context "${MY_CLUSTER_CONTEXT}" && \
 kubectl get pods -n istio-system --context "${MY_CLUSTER_CONTEXT}" && \
 kubectl get pods -n istio-gateways --context "${MY_CLUSTER_CONTEXT}"
@@ -552,5 +552,6 @@ kubectl get pods -n istio-gateways --context "${MY_CLUSTER_CONTEXT}"
 
 ### Visualize in Gloo Mesh Dashboard
 Access Gloo Mesh Dashboard at `http://localhost:8090`:
-```
+```bash
 kubectl port-forward -n gloo-mesh svc/gloo-mesh-ui 8090 --context "${MY_CLUSTER_CONTEXT}"
+```

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ spec:
         telemetryGateway:
           enabled: true
           service:
-            type: LoadBalancer
+            type: ClusterIP
         telemetryCollector:
           enabled: true
           config:
@@ -209,13 +209,15 @@ kubectl get pods -n gloo-mesh  --context "${MY_CLUSTER_CONTEXT}"
 
 Output should look similar to below:
 ```bash
-NAME                                     READY   STATUS    RESTARTS   AGE
-gloo-mesh-redis-788545948f-r2lp6         1/1     Running   0          10m
-gloo-telemetry-gateway-677b9b65f-nnl7z   1/1     Running   0          10m
-gloo-mesh-mgmt-server-5ddc5f8b6b-rpkwz   1/1     Running   0          10m
-gloo-mesh-ui-6879b5c9cc-ffbzk            3/3     Running   0          10m
-prometheus-server-6d8c8bc5b9-sjszn       2/2     Running   0          10m
-gloo-mesh-agent-5c549ccb4b-lxjdp         1/1     Running   0          10m
+NAME                                      READY   STATUS    RESTARTS   AGE
+gloo-mesh-agent-7b79dd5c9-hfw9p           1/1     Running   0          62s
+gloo-mesh-mgmt-server-7f6968d9b9-67l7j    1/1     Running   0          62s
+gloo-mesh-redis-84f57d46bc-dwqx9          1/1     Running   0          62s
+gloo-mesh-ui-56879cb8b-52vpx              3/3     Running   0          61s
+gloo-telemetry-collector-agent-7fgb5      1/1     Running   0          62s
+gloo-telemetry-collector-agent-txwbm      1/1     Running   0          62s
+gloo-telemetry-gateway-5445d7d6b5-5k9sd   1/1     Running   0          62s
+prometheus-server-565cb79f89-jc5ns        2/2     Running   0          62s
 ```
 
 ### install `meshctl`

--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ CURRENT   NAME   CLUSTER    AUTHINFO         NAMESPACE
 #### Renaming Cluster Context
 If your local clusters have a different context name, you will want to have it match the expected context name(s). In this example, we are setting the context name as `gloo`.
 
-```
+```bash
 export MY_CLUSTER_CONTEXT=gloo
+export MY_CLUSTER_NAME=k3d-gloo
 ```
+
 ```bash
 kubectl config rename-context <k3d-your_cluster_name> "${MY_CLUSTER_CONTEXT}"
 ```
@@ -61,13 +63,13 @@ kubectl get pods -n argocd --context "${MY_CLUSTER_CONTEXT}"
 Output should look similar to below
 ```bash
 NAME                                                READY   STATUS    RESTARTS   AGE
-argocd-application-controller-0                     1/1     Running   0          4m22s
-argocd-applicationset-controller-765944f45d-g7mrr   1/1     Running   0          4m24s
-argocd-dex-server-7977459848-vdptg                  1/1     Running   0          4m24s
-argocd-notifications-controller-6587c9d9-wzxc6      1/1     Running   0          4m23s
-argocd-redis-b5d6bf5f5-95tm5                        1/1     Running   0          4m23s
-argocd-repo-server-7bfc968f69-xw5h5                 1/1     Running   0          4m23s
-argocd-server-77f84bfbb8-tdmwf                      2/2     Running   0          4m23s
+argocd-application-controller-0                     1/1     Running   0          31s
+argocd-applicationset-controller-765944f45d-569kn   1/1     Running   0          33s
+argocd-dex-server-7977459848-swnm6                  1/1     Running   0          33s
+argocd-notifications-controller-6587c9d9-6t4hg      1/1     Running   0          32s
+argocd-redis-b5d6bf5f5-52mk5                        1/1     Running   0          32s
+argocd-repo-server-7bfc968f69-hrqt6                 1/1     Running   0          32s
+argocd-server-77f84bfbb8-lgdlr                      2/2     Running   0          32s
 ```
 
 We can also change the password to: `admin / solo.io`:
@@ -94,7 +96,11 @@ GLOO_MESH_LICENSE_KEY=<input_license_key_here>
 ```
 
 ## Installing Gloo Mesh
-Gloo Mesh can be installed and configured easily using Helm + Argo CD. To install Gloo Mesh Enterprise 2.4.6
+Gloo Mesh can be installed and configured easily using Helm + Argo CD. To install Gloo Mesh Enterprise 2.4.7
+
+```bash
+export GLOO_MESH_VERSION=2.4.7
+```
 
 First we will deploy the Gloo Platform CRD helm chart using an Argo Application
 ```bash
@@ -112,7 +118,7 @@ spec:
   source:
     chart: gloo-platform-crds
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.4.6
+    targetRevision: "${GLOO_MESH_VERSION}"
   syncPolicy:
     automated:
       prune: true
@@ -182,7 +188,7 @@ spec:
           relay:
             serverAddress: gloo-mesh-mgmt-server:9900
     repoURL: https://storage.googleapis.com/gloo-platform/helm-charts
-    targetRevision: 2.4.6
+    targetRevision: "${GLOO_MESH_VERSION}"
   syncPolicy:
     automated:
       prune: true
@@ -214,7 +220,7 @@ gloo-mesh-agent-5c549ccb4b-lxjdp         1/1     Running   0          10m
 
 ### install `meshctl`
 ```bash
-curl -sL https://run.solo.io/meshctl/install | GLOO_MESH_VERSION=v2.4.6 sh - ;
+curl -sL https://run.solo.io/meshctl/install | GLOO_MESH_VERSION="v${GLOO_MESH_VERSION}" sh - ;
 export PATH=$HOME/.gloo-mesh/bin:$PATH
 ```
 

--- a/README.md
+++ b/README.md
@@ -96,14 +96,12 @@ GLOO_MESH_LICENSE_KEY=<input_license_key_here>
 ```
 
 ## Installing Gloo Mesh
-Gloo Mesh can be installed and configured easily using Helm + Argo CD. To install Gloo Mesh Enterprise 2.4.7
-
-```bash
-export GLOO_MESH_VERSION=2.4.7
-```
+Gloo Mesh can be installed and configured easily using Helm + Argo CD. To install Gloo Mesh Enterprise
 
 First we will deploy the Gloo Platform CRD helm chart using an Argo Application
 ```bash
+export GLOO_MESH_VERSION=2.4.7;
+
 kubectl apply --context "${MY_CLUSTER_CONTEXT}" -f- <<EOF
 apiVersion: argoproj.io/v1alpha1
 kind: Application


### PR DESCRIPTION
- Code block rendering added in a few places
- Added meshctl install, post-install verification steps
- Added GLOO_MESH_VERSION env var to generalize install steps
- Using MY_CLUSTER_NAME env var instead of `gloo` so that we can replace with user cluster name when required
- using ISTIO_VERSION env var instead of actual values
- `service.beta.kubernetes.io/aws-load-balancer-type` annotation value changed to `"nlb-ip"`